### PR TITLE
Add deprecated message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ on:
     branches:
       - main
 
-# The job level concurrency
+# The workflow level concurrency
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency: deploy
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,42 @@ A GitHub Action for exclusive control.
 
 - avoid running multiple jobs concurrently across workflows
 
+## OFFICIAL CONCURRENCY SUPPORT ON GITHUB ACTIONS
+
+The action is no longer maintained.
+
+On April 19, 2021, GitHub launched support for limiting concurrency in the workflow files.
+Please consider to use this feature.
+
+- [GitHub Actions: Limit workflow run or job concurrency](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/)
+
+Using this feature, the example in the SYNOPSIS section may be:
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+# The job level concurrency
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency: deploy
+
+jobs:
+  build:
+
+    # The job level concurrency
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency
+    concurrency: deploy
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: ': some jobs that can not run concurrently'
+```
+
+Please read the latest document of [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+
 ## SYNOPSIS
 
 ```yaml
@@ -47,39 +83,6 @@ The default is the repository that the workflow runs on.
 
 Prefix of branch names for locking.
 The default is "actions-mutex-lock/"
-
-## OFFICIAL CONCURRENCY SUPPORT ON GITHUB ACTIONS
-
-On April 19, 2021, GitHub launched beta support for limiting concurrency in the workflow files.
-
-- [GitHub Actions: Limit workflow run or job concurrency](https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/)
-
-Using this feature, the example in the SYNOPSIS section may be:
-
-```yaml
-on:
-  push:
-    branches:
-      - main
-
-# The job level concurrency
-# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
-concurrency: deploy
-
-jobs:
-  build:
-
-    # The job level concurrency
-    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency
-    concurrency: deploy
-
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: ': some jobs that can not run concurrently'
-```
-
-Please read the latest document of [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
 
 ## HOW THE ACTION WORKS
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
       - run: ': some jobs that can not run concurrently'
 ```
 
-Note: Concurrency is currently in beta and subject to change. Please read the latest document of [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
+Please read the latest document of [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).
 
 ## HOW THE ACTION WORKS
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,12 @@ import * as lock from './lock'
 
 async function run() {
   try {
+    core.warning(
+      'shogo82148/actions-mutex is no longer maintained. ' +
+        'Please consider use official support for limiting concurrency. ' +
+        'https://github.com/shogo82148/actions-mutex#official-concurrency-support-on-github-actions'
+    )
+
     const required = {
       required: true
     }


### PR DESCRIPTION
It looks that official support for limiting concurrency is out of beta.

- https://github.com/github/docs/commit/3040c3fcbd061689770521c16b17bb8b7b520419

I recommend the users to the official feature.
